### PR TITLE
Fix 'Admob' to 'Firestore' and typo

### DIFF
--- a/v3.0.*/firestore/android.md
+++ b/v3.0.*/firestore/android.md
@@ -4,7 +4,7 @@ First ensure you have followed the [initial setup guide](version /installation/i
 
 ## Add the dependency
 
-Add the Firebase Admob dependancy to `android/app/build.gradle`:
+Add the Firebase Firestore dependency to `android/app/build.gradle`:
 
 ```
 dependencies {


### PR DESCRIPTION
Just fixed what looked like a copy and paste from the Admob module section.  Also, it looks like 'dependency' is misspelled as 'dependancy' in all of the module Android installation sections.