### PR TITLE
Fix location of setPersistenceEnabled in Android

### DIFF
--- a/v3.0.*/core/default-app.md
+++ b/v3.0.*/core/default-app.md
@@ -20,7 +20,7 @@ You can still however easily enable this natively for the default app instance:
 
 ### Android
 
-Add the below line inside your `MainActivity.java` file `onCreate()` method:
+Add the below line inside your `MainApplication.java` file `onCreate()` method:
 
 ```java
 FirebaseDatabase.getInstance().setPersistenceEnabled(true);

--- a/v3.0.*/migration-guide.md
+++ b/v3.0.*/migration-guide.md
@@ -17,7 +17,7 @@ npm install react-native-firebase@latest --save`
 ## 3) Update your code to reflect deprecations/breaking changes if needed:
 
 - ![#f03c15](https://placehold.it/15/f03c15/000000?text=+) **[breaking]** [database] enabling database persistence (setPersistence) via JS is no longer supported - this is to prevent several race conditions. See sub points on how to enable these natively.
-  - [android] add `FirebaseDatabase.getInstance().setPersistenceEnabled(true);` to your `MainActivity` `onCreate` method.
+  - [android] add `FirebaseDatabase.getInstance().setPersistenceEnabled(true);` to your `MainApplication` `onCreate` method.
   - [ios]  add `[FIRDatabase database].persistenceEnabled = YES;` after the `[FIRApp configure];` line  inside your `AppDelegate` `didFinishLaunchingWithOptions` method.
 - ![#f03c15](https://placehold.it/15/f03c15/000000?text=+) **[breaking]** [app] `new RNFirebase()` is no longer supported. See below for information about app initialisation.
 - ![#f03c15](https://placehold.it/15/fdfd96/000000?text=+) **[deprecated]** [app] `initializeApp()` for apps that are already initialised natively (i.e. the default app initialised via google-services plist/json) will now log a deprecation warning.

--- a/v3.0.*/release-notes.md
+++ b/v3.0.*/release-notes.md
@@ -11,7 +11,7 @@ and follow the migration guide below (there isn't much to change).
 ## Known Issues
 
  - Currently no way (in JS) to set database persistence, you can however set this natively:
-    - [android] add `FirebaseDatabase.getInstance().setPersistenceEnabled(true);` to your `MainActivity` `onCreate` method.
+    - [android] add `FirebaseDatabase.getInstance().setPersistenceEnabled(true);` to your `MainApplication` `onCreate` method.
     - [ios] add `[FIRDatabase database].persistenceEnabled = YES;` after the `[FIRApp configure];` line  inside your `AppDelegate` `didFinishLaunchingWithOptions` method.
  - Currently no way to enable RNFirebase debug logging.
  - [android] no play store/play services version checks and associated methods.


### PR DESCRIPTION
### Issue
* If `setPersistenceEnabled` is in `MainActivity`, it can raise a error such as `Calls to setPersistenceEnabled() must be made before any other usage of FirebaseDatabase instance`.

### Solution reference
* https://stackoverflow.com/questions/37753991/com-google-firebase-database-databaseexception-calls-to-setpersistenceenabled/37766261#37766261