### PR TITLE
Analytics Pod doesn't need to be included

### DIFF
--- a/v3.1.*/analytics/ios.md
+++ b/v3.1.*/analytics/ios.md
@@ -1,13 +1,5 @@
 # iOS Installation
 
-First ensure you have followed the [initial setup guide](version /installation/initial-setup).
+Ensure you have followed the [initial setup guide](version /installation/initial-setup).
 
-## Add the pod
-
-Add the following to your `Podfile`:
-
-```ruby
-pod 'Firebase/Analytics'
-```
-
-Run `pod update`.
+That is it, Analytics doesn't need anything else to work.


### PR DESCRIPTION
[Firebase doc](https://firebase.google.com/docs/analytics/ios/start) mentions that only `pod 'Firebase/Core'` is required to analytics.