### PR TITLE
Make social login instructions easier to use

### DIFF
--- a/v3.1.*/auth/social-auth.md
+++ b/v3.1.*/auth/social-auth.md
@@ -12,32 +12,36 @@ The `react-native-fbsdk` library allows us to first login (using `LoginManager`)
 
 ```js
 import { AccessToken, LoginManager } from 'react-native-fbsdk';
+import firebase from 'react-native-firebase'
 
-// ... somewhere in your login screen component
-LoginManager
-  .logInWithReadPermissions(['public_profile', 'email'])
-  .then((result) => {
-    if (result.isCancelled) {
-      return Promise.reject(new Error('The user cancelled the request'));
-    }
-    
-    console.log(`Login success with permissions: ${result.grantedPermissions.toString()}`);
-    // get the access token
-    return AccessToken.getCurrentAccessToken();
-  })
-  .then(data => {
-    // create a new firebase credential with the token
-    const credential = firebase.auth.FacebookAuthProvider.credential(data.accessToken);
-
-    // login with credential
-    return firebase.auth().signInWithCredential(credential);
-  })
-  .then((currentUser) => {
-      console.warn(JSON.stringify(currentUser.toJSON()));
-  })
-  .catch((error) => {
-    console.log(`Login fail with error: ${error}`);
-  });
+// Calling the following function will open the FB login dialogue:
+const facebookLogin = () => {
+  return LoginManager
+    .logInWithReadPermissions(['public_profile', 'email'])
+    .then((result) => {
+      if (!result.isCancelled) {
+        console.log(`Login success with permissions: ${result.grantedPermissions.toString()}`)
+        // get the access token
+        return AccessToken.getCurrentAccessToken()
+      }
+    })
+    .then(data => {
+      if (data) {
+        // create a new firebase credential with the token
+        const credential = firebase.auth.FacebookAuthProvider.credential(data.accessToken)
+        // login with credential
+        return firebase.auth().signInWithCredential(credential)
+      }
+    })
+    .then((currentUser) => {
+      if (currentUser) {
+        console.info(JSON.stringify(currentUser.toJSON()))
+      }
+    })
+    .catch((error) => {
+      console.log(`Login fail with error: ${error}`)
+    })
+}
 ```
 
 ## Google


### PR DESCRIPTION
While implementing social login, I noticed that I couldn't simply drag and drop for the expected functionality to work. After implementing it in my project, these functions should work automatically for users who want to get started right away. (For instance, I had to call `.configure()` before being able to use the google auth, which I didn't know from using the given example.)