### PR TITLE
One-line documentation fix

### DIFF
--- a/docs/firestore/reference/DocumentSnapshot.md
+++ b/docs/firestore/reference/DocumentSnapshot.md
@@ -10,7 +10,7 @@ A DocumentSnapshot contains data read from a document in your Cloud Firestore da
 Property of the DocumentSnapshot that signals whether or not the data exists. True if the document exists.
 
 ### id
-[method]exists returns string;[/method]
+[method]id returns string;[/method]
 
 Property of the DocumentSnapshot that provides the document's ID.
 


### PR DESCRIPTION
The documentation for the `id` field had a copy-paste mistake from the `exists` field documentation. This mistake is now fixed.