### PR TITLE
problem with phone auth full example

### DIFF
--- a/docs/auth/phone-auth.md
+++ b/docs/auth/phone-auth.md
@@ -126,7 +126,7 @@ export default class PhoneAuthTest extends Component {
   renderMessage() {
     const { message } = this.state;
   
-    if (!!message.length) return null;
+    if (!message.length) return null;
   
     return (
       <Text style={{ padding: 5, backgroundColor: '#000', color: '#fff' }}>{message}</Text>


### PR DESCRIPTION
`if (!!message.length) return null;`

is always true if there is a message, returning null will swallow the message.
