### PR TITLE
add launchMode="singleTask" mention to android links doc

### DIFF
--- a/docs/links/android.md
+++ b/docs/links/android.md
@@ -56,5 +56,13 @@ public class MainApplication extends Application implements ReactApplication {
         <data android:host="your.dynamic.links.domain.example.com" android:scheme="https"/>
     </intent-filter>
     ```
+    
+3. If you wish to receive the intent in an existing instance of MainActivity, you may set the launchMode of MainActivity to singleTask in AndroidManifest.xml. See [<activity>](https://developer.android.com/guide/topics/manifest/activity-element.html) documentation for more information.
+
+    ```xml
+    <activity
+      android:name=".MainActivity"
+      android:launchMode="singleTask">
+    ```
 
 > For more information on Analytics for links or Handling Dynamic Links using App Links see the official [Firebase Android SDK docs](https://firebase.google.com/docs/dynamic-links/android/receive#record-analytics)


### PR DESCRIPTION
As mentioned in react-native linking docs: https://facebook.github.io/react-native/docs/linking.html#docsNav and in one of the issues I experienced recently https://github.com/invertase/react-native-firebase/issues/826

Android opens new intents when app is opened via dynamic link and breaks whole flow, its fixable by adding  `launchMode="singleTask"` to manifest.