### PR TITLE
Fix code formatting in iOS linking docs

### DIFF
--- a/docs/links/ios.md
+++ b/docs/links/ios.md
@@ -89,13 +89,17 @@ Run `pod update`.
     > if that is the case you can perform check below
 
     ```objectivec
-    - (BOOL)application:(UIApplication *)application openURL:(NSURL *)url options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options {
-        // Set handled link to facebook sdk check
-        BOOL handled = [[FBSDKApplicationDelegate sharedInstance] application:application openURL:url sourceApplication:options[UIApplicationOpenURLOptionsSourceApplicationKey] annotation:options[UIApplicationOpenURLOptionsAnnotationKey]];
-
-        // If link was not matched against facebook SDK
+    - (BOOL)application:(UIApplication *)application 
+    openURL:(NSURL *)url 
+    options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options {
+    
+        BOOL handled = [[FBSDKApplicationDelegate sharedInstance] 
+        application:application 
+        openURL:url 
+        sourceApplication:options[UIApplicationOpenURLOptionsSourceApplicationKey] 
+        annotation:options[UIApplicationOpenURLOptionsAnnotationKey]];
+        
         if (!handled) {
-            // Set handled link to RNFirebase
             handled = [RNFirebaseLinks application:application openURL:url options:options];
         } 
 


### PR DESCRIPTION
If you scroll to the very bottom of https://rnfirebase.io/docs/v3.3.x/links/ios you'll see that code formatting is off

<img width="722" alt="screen shot 2018-03-13 at 12 23 57" src="https://user-images.githubusercontent.com/3154053/37336288-9b54078a-26b9-11e8-8195-ff40d175887d.png">
