### PR TITLE
Update ios.md

### DIFF
--- a/docs/database/ios.md
+++ b/docs/database/ios.md
@@ -10,4 +10,4 @@ Add the following to your `Podfile`:
 pod 'Firebase/Database'
 ```
 
-Run `pod update`.
+Run `pod install`.


### PR DESCRIPTION
pod update does nothing. A pod install is what's required. Note that all other iOS installation instructions require this same change: cloud messaging, etc.