### PR TITLE
Update missing information to documentation

### DIFF
--- a/docs/notifications/ios.md
+++ b/docs/notifications/ios.md
@@ -28,7 +28,13 @@ Add the following method:
 
 ## Remote Notifications (Optional)
 
-If you would like to support Remote Notifications via FCM, add the following methods to your `ios/[App Name]/AppDelegate.m`:
+If you would like to support Remote Notifications via FCM, also add the following import to the top of your `ios/[App Name]/AppDelegate.m`:
+
+```objectivec
+#import "RNFirebaseMessaging.h"
+```
+
+Then add the following methods to your `ios/[App Name]/AppDelegate.m`:
 
 ```objectivec
 - (void)application:(UIApplication *)application didReceiveRemoteNotification:(nonnull NSDictionary *)userInfo


### PR DESCRIPTION
Following the steps described in this docs, the build failed because the `RNFirebaseMessaging` was not defined.

I'm proposing this simple change in the text to make it more clear.

Thank you guys for the amazing job with this library. =)