### PR TITLE
Update incorrect method name

### DIFF
--- a/docs/messaging/device-token.md
+++ b/docs/messaging/device-token.md
@@ -41,7 +41,7 @@ The `onTokenRefresh` callback fires with the latest registration token whenever 
 
 ```js
 componentDidMount() {
-    this.onTokenRefreshListener = firebase.messaging().onTokenRefreshed(fcmToken: string => {
+    this.onTokenRefreshListener = firebase.messaging().onTokenRefresh(fcmToken: string => {
         // Process your token as required
     });
 }


### PR DESCRIPTION
The example provided uses an incorrect method name `onTokenRefreshed()`. I'm updating it with the correct name, `onTokenRefresh()`