### PR TITLE
Add `multiDexEnabled true` to Android setup

### DIFF
--- a/docs/firestore/android.md
+++ b/docs/firestore/android.md
@@ -13,6 +13,18 @@ dependencies {
 }
 ```
 
+## Enable multi DEX
+Make sure you have `multiDexEnabled true` in `android/app/build.gradle`:
+```groovy
+android {
+    // ...
+    defaultConfig {
+        // ...
+        multiDexEnabled true
+    }
+}
+```
+
 ## Install the RNFirebase Firestore package
 
 Add the `RNFirebaseFirestorePackage` to your `android/app/src/main/java/com/[app name]/MainApplication.java`:


### PR DESCRIPTION
This is to align the docs with Starter kit: https://github.com/invertase/react-native-firebase-starter/blob/2a76b89a5cd8ed4b7e7af9a9072e9ad79e80c143/android/app/build.gradle#L114. The build does not currently work without this.