### PR TITLE
Fix wrong method name in Admob Interstitial docs

### DIFF
--- a/docs/admob/reference/Interstitial.md
+++ b/docs/admob/reference/Interstitial.md
@@ -18,7 +18,7 @@ Starting loading an interstial from the Firebase servers with a given [ref admob
 | request   | **[ref admob.AdRequest#build]** <br /> An AdRequest.build object |
 
 ### on
-[method]loadAd(event, callback) returns void;[/method]
+[method]on(event, callback) returns void;[/method]
 
 Listens for advert events. See [EventTypes](version /admob/reference#eventtypes) for more information.
 


### PR DESCRIPTION
Hey,

Here is just a little typo fix for the `on` method.

By the way, I was wondering why there is nothing on [the reference page](https://rnfirebase.io/docs/v3.3.x/admob/reference/admob) ? There should be #EventTypes and other references, right ?