### PR TITLE
Update link to Android installation instructions

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -173,7 +173,7 @@ implementation(project(':react-native-firebase')) {
 As you can imagine, for Messaging and Notifications this is a completely breaking change, so you'll want to follow the installation instructions available here:
 
 - Messaging: [iOS](https://rnfirebase.io/docs/v4.0.x/messaging/ios) | [Android](https://rnfirebase.io/docs/v4.0.x/messaging/android)
-- Notifications: [iOS](https://rnfirebase.io/docs/v4.0.x/notifications/ios) | [Android](https://rnfirebase.io/docs/v4.0.x/messaging/android)
+- Notifications: [iOS](https://rnfirebase.io/docs/v4.0.x/notifications/ios) | [Android](https://rnfirebase.io/docs/v4.0.x/notifications/android)
 
 There are a number of guides available: [Messaging](https://rnfirebase.io/docs/v4.0.x/messaging/introduction) | [Notifications](https://rnfirebase.io/docs/v4.0.x/notifications/introduction)
 


### PR DESCRIPTION
Previously, the Notifications installation instructions for Android was the same as the link for Messaging, updated Readme.MD to route to the proper Notification installation link