### PR TITLE
Update fabric version

### DIFF
--- a/docs/crashlytics/android.md
+++ b/docs/crashlytics/android.md
@@ -23,7 +23,7 @@ buildscript {
   dependencies {
     // ...
     classpath 'com.google.gms:google-services:{{ android.google.services }}'
-    classpath 'io.fabric.tools:gradle:{{ android.fabric.gradle }}'
+    classpath 'io.fabric.tools:gradle:{{ android.fabric.tools }}'
   }
 }
 ```


### PR DESCRIPTION
Looks like this was updated in the `_config.yaml` to be `tools` instead of `gradle`. Updating so version is included.