### PR TITLE
updated Android docs.

### DIFF
--- a/docs/installation/android.md
+++ b/docs/installation/android.md
@@ -94,6 +94,7 @@ allprojects {
         maven {
             // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
             url "$rootDir/../node_modules/react-native/android"
+            url "https://maven.google.com"
         }
         // -------------------------------------------------
         // Add this below the existing maven property above


### PR DESCRIPTION
url "https://maven.google.com" is required for the build to work.