### PR TITLE
Include android setChannelId and setSmallIcon guidance in documentation

### DIFF
--- a/docs/notifications/displaying-notifications.md
+++ b/docs/notifications/displaying-notifications.md
@@ -27,8 +27,8 @@ As Android provides some bespoke notification functionality, we have segregated 
 
 ```js
 notification
-  .android.setChannelId('channelId')
-  .android.setSmallIcon('ic_launcher');
+  .android.setChannelId('your_channel_id')
+  .android.setSmallIcon('icon_name');
 ```
 
 For the full set of Android-specific parameters that can be set, please see the [ref notifications.AndroidNotification] reference docs.

--- a/docs/notifications/displaying-notifications.md
+++ b/docs/notifications/displaying-notifications.md
@@ -46,9 +46,17 @@ For the full set of iOS-specific parameters that can be set, please see the [ref
 
 ## 2) Display the notification
 
-### (Android) Set up a notification channel
+### Android Specific
 
 Before you can display a notification on Android, you must ensure you have created a Notification Channel, as explained [here](version /notifications/android-channels).
+
+Additionally, you must ensure the following have been set, otherwise local notifications will not display:
+
+```js
+notification
+  .android.setChannelId('channelId')
+  .android.setSmallIcon('ic_launcher');
+```
 
 ### Display the notification
 

--- a/docs/notifications/displaying-notifications.md
+++ b/docs/notifications/displaying-notifications.md
@@ -27,8 +27,8 @@ As Android provides some bespoke notification functionality, we have segregated 
 
 ```js
 notification
-  .android.setChannelId('your_channel_id')
-  .android.setSmallIcon('icon_name');
+  .android.setChannelId('channelId')
+  .android.setSmallIcon('ic_launcher');
 ```
 
 For the full set of Android-specific parameters that can be set, please see the [ref notifications.AndroidNotification] reference docs.
@@ -54,8 +54,8 @@ Additionally, you must ensure the following have been set, otherwise local notif
 
 ```js
 notification
-  .android.setChannelId('channelId')
-  .android.setSmallIcon('ic_launcher');
+  .android.setChannelId('your_channel_id')
+  .android.setSmallIcon('icon_name');
 ```
 
 ### Display the notification


### PR DESCRIPTION
I've just spent the better part of a day trying to display notifications which come through when the app is in the foreground, as passing them straight through to `displayNotification()` always fails. It turns out that local notifications need these options set explicitly by the codebase, even when the foreground handler picks up a backend message.

Would be really useful to clarify this in the docs for future users!