### PR TITLE
Facebook profile picture expiration

### DIFF
--- a/docs/auth/social-auth.md
+++ b/docs/auth/social-auth.md
@@ -45,6 +45,10 @@ const facebookLogin = async () => {
 }
 ```
 
+### Caveat: profile picture expiration
+
+The Facebook profile picture URL provided by `firebase.auth().currentUser.photoUrl` has an expiration date: after a few days you will get an `URL signature expired` error. A workaround is either to store the image in your database or to use `firebase.auth().currentUser.providerData[0].photoURL + '?height=' + myCustomHeight`.
+
 ## Google
 
 We recommend using [react-native-google-signin](https://github.com/devfd/react-native-google-signin) for Google authentication.  This module handles the flow of logging in a user and obtaining their `accessToken` and `idToken` by wrapping around the offical Google login library. This means you get a much smoother experience than using a standard OAuth library, particularly on Android.


### PR DESCRIPTION
Hi 

Firstly, thank you for all the great work :)

I was using `firebase.auth().currentUser.photoUrl` to display the user's profile picture in my app. After a few days, the picture disappeared. I tested the URL in my navigator and I got the following error: `URL signature expired`. I found a workaround (see the doc suggestion).

I'm not sure about the right approach: 
- should we just document this ?
- should I make an issue on react-native-firebase so that `firebase.auth().currentUser.photoUrl`gets regularly refreshed ?

What do you think ?
