### PR TITLE
Update react-native-google-signin Github address

### DIFF
--- a/docs/auth/social-auth.md
+++ b/docs/auth/social-auth.md
@@ -47,7 +47,7 @@ const facebookLogin = async () => {
 
 ## Google
 
-We recommend using [react-native-google-signin](https://github.com/devfd/react-native-google-signin) for Google authentication.  This module handles the flow of logging in a user and obtaining their `accessToken` and `idToken` by wrapping around the offical Google login library. This means you get a much smoother experience than using a standard OAuth library, particularly on Android.
+We recommend using [react-native-google-signin](https://github.com/react-native-community/react-native-google-signin) for Google authentication.  This module handles the flow of logging in a user and obtaining their `accessToken` and `idToken` by wrapping around the offical Google login library. This means you get a much smoother experience than using a standard OAuth library, particularly on Android.
 
 The `react-native-google-signin` library allows us to login (using `GoogleSignin`) which returns an optional `accessToken` and `idToken`. Once we have the two tokens we need to create a credential using [ref auth.GoogleAuthProvider#credential] and then sign in with that credential using [ref auth#signInWithCredential]:
 


### PR DESCRIPTION
I noticed that the address is pointing to old repository. Old link still redirects to the new one but it's better to use the latest url.