### PR TITLE
Update Firestore android.md

### DIFF
--- a/docs/firestore/android.md
+++ b/docs/firestore/android.md
@@ -37,3 +37,20 @@ public class MainApplication extends Application implements ReactApplication {
   // ...
 }
 ```
+
+## Enable multidex
+
+Adding Firestore to your Android app requires [`multiDexEnabled` to be set to `true`](https://developer.android.com/studio/build/multidex)
+
+```java
+//..
+android {
+  //..
+  
+  defaultConfig {
+    //..
+    multiDexEnabled true  // needed for firestore:
+  }
+  //..
+}
+```


### PR DESCRIPTION
Firestore on Android requires multidex to be enabled so I've updated the documentation to reflect this. 
Without this change the app won't build for Android