### PR TITLE
docs: Update User.UserMetadata timestamp formats to match plugin return vals

### DIFF
--- a/docs/auth/reference/UserMetadata.md
+++ b/docs/auth/reference/UserMetadata.md
@@ -7,9 +7,9 @@ Interface representing a user's metadata.
 ### creationTime
 [method]creationTime returns nullable string;[/method]
 
-The date the user was created, formatted as a UTC string. For example, 'Fri, 22 Sep 2017 01:49:58 GMT'.
+The date the user was created. This should be (and will be, in v6) a UTC string, for example 'Fri, 22 Sep 2017 01:49:58 GMT', but in v5 it is formatted as a string containing the time in milliseconds since 1 Jan 1970 UTC. For example, '1554052020521'.
 
 ### lastSignInTime
 [method]lastSignInTime returns nullable string;[/method]
 
-The date the user last signed in, formatted as a UTC string. For example, 'Fri, 22 Sep 2017 01:49:58 GMT'.
+The date the user last signed in, This should be (and will be, in v6) a UTC string, for example 'Fri, 22 Sep 2017 01:49:58 GMT', but in v5 it is formatted as a string containing the time in milliseconds since 1 Jan 1970 UTC. For example, '1554052020521'.


### PR DESCRIPTION
For the 5.x Auth version now, I noticed the User.UserMetadata times were coming back as standard Date milliseconds values, and thought the documentation should match