### PR TITLE
docs: noted iOS pod needed for iOS audience stats

### DIFF
--- a/docs/analytics/ios.md
+++ b/docs/analytics/ios.md
@@ -2,4 +2,11 @@
 
 Ensure you have followed the [initial setup guide](version /installation/initial-setup).
 
-That is it, Analytics doesn't need anything else to work.
+## Device Identification
+
+If you would like to enable Firebase Analytics to generate automatic audience metrics for iOS (as it does by default in Android), you must link additional iOS libraries, [as documented by the Google Firebase team](https://support.google.com/firebase/answer/6318039). Specifically you need libAdIdAccess.a and AdSupport.framework
+
+The way to do this using Cocoapods is to add this to your Podfile (though please use [the most current Pod version](https://cocoapods.org/pods/GoogleIDFASupport) supported by react-native-firebase):
+```ruby
+  pod 'GoogleIDFASupport', '~> 3.14.0'
+```


### PR DESCRIPTION
Per discussion on https://github.com/invertase/react-native-firebase/issues/2071 - added a note about the cocoapod required for automatic audience metric collection on iOS

This is the PR for v5.x.x