### PR TITLE
docs: notice semver policy change, update dep versions, fill changelog

### DIFF
--- a/docs/_config.yaml
+++ b/docs/_config.yaml
@@ -2,16 +2,15 @@ android:
   build:
     tools: 3.3.2
   fabric:
-    tools: 1.25.4
-    version: 2.9.5
+    tools: 1.28.1
   firebase:
-    version: 16.0.8
-    ads: 15.0.1
+    version: 16.0.9
+    ads: 17.2.1
     analytics: 16.5.0
     auth: 17.0.0
     config: 17.0.0
     core: 16.0.9
-    crashlytics: 2.9.5
+    crashlytics: 2.9.9
     database: 17.0.0
     firestore: 19.0.0
     functions: 17.0.0
@@ -19,26 +18,25 @@ android:
     messaging: 18.0.0
     perf: 16.2.5
     storage: 17.0.0
-    plugins: 1.1.5
+    plugins: 1.2.1
   gms:
     google-services: 4.2.0
     play-services-base: 16.1.0
 ios:
   fabric:
-    tools: 1.9.0
-    version: 3.10.9
+    tools: 1.10.1
   firebase:
-    ads: 5.20.1
-    auth: 5.20.1
-    config: 5.20.1
-    core: 5.20.1
-    crash: 5.20.1
-    crashlytics: 3.12.0
-    database: 5.20.1
-    firestore: 5.20.1
-    functions: 5.20.1
-    invites: 5.20.1
-    links: 5.20.1
-    messaging: 5.20.1
-    perf: 5.20.1
-    storage: 5.20.1
+    ads: 5.20.2
+    auth: 5.20.2
+    config: 5.20.2
+    core: 5.20.2
+    crash: 5.20.2
+    crashlytics: 3.13.1
+    database: 5.20.2
+    firestore: 5.20.2
+    functions: 5.20.2
+    invites: 5.20.2
+    links: 5.20.2
+    messaging: 5.20.2
+    perf: 5.20.2
+    storage: 5.20.2

--- a/docs/admob/android.md
+++ b/docs/admob/android.md
@@ -37,3 +37,19 @@ public class MainApplication extends Application implements ReactApplication {
   // ...
 }
 ```
+
+## Update Android Manifest
+
+Add the following to `android/app/src/main/AndroidManifest.xml`:
+
+Within the application component, add your AdMob ID (from the AdMob UI):
+```xml
+<application ...>
+  <!-- Sample AdMob App ID: ca-app-pub-3940256099942544~3347511713 -->
+  <meta-data
+    android:name="com.google.android.gms.ads.APPLICATION_ID"
+    android:value="YOUR_ADMOB_APP_ID"/>
+</application>
+```
+
+> Important: This step is required as of Google Mobile Ads SDK version 17.0.0. Failure to add this `<meta-data>` tag results in a crash with the message: "The Google Mobile Ads SDK was initialized incorrectly."

--- a/docs/admob/ios.md
+++ b/docs/admob/ios.md
@@ -11,3 +11,14 @@ pod 'Firebase/AdMob', '~> {{ ios.firebase.ads }}'
 ```
 
 Run `pod update`.
+
+## Update your plist file
+
+In your app's `Info.plist` file, add a GADApplicationIdentifier key with a string value of your AdMob app ID. You can find your App ID in the AdMob UI.
+
+It should look like this, but with your ID, not the sample ID used below:
+
+```xml
+  <key>GADApplicationIdentifier</key>
+  <string>ca-app-pub-3940256099942544~1458002511</string>
+```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -72,7 +72,7 @@ For feature requests please visit our [Feature Request Board](https://boards.inv
 
 ## Changelog
 
-Detailed changes for each release are documented in the [releases notes](https://github.com/invertase/react-native-firebase/releases).
+Detailed changes for each release are documented in the [release notes](/docs/v5.x.x/release-notes).
 
 ## Contributing
 

--- a/docs/installation/initial-setup.md
+++ b/docs/installation/initial-setup.md
@@ -6,6 +6,8 @@ Install React Native Firebase from NPM:
 npm install --save react-native-firebase
 ```
 
+!> **Semver warning:** while v5 is in long-term maintenance during the v6 transition, v5 will allow *breaking change* in minior releases. Configure your `package.json` dependency to use the '~' semver range instead of '^' to avoid unexpected breaking change.
+
 ## Firebase
 
 The first thing you'll need to have is an active Firebase project.

--- a/docs/perf-mon/android.md
+++ b/docs/perf-mon/android.md
@@ -13,14 +13,16 @@ dependencies {
 }
 ```
 
-Performance Monitoring also requires the Firebase Plugins dependency. In your projects `android/build.gradle` file, add the plugin to your dependencies:
+Performance Monitoring also requires the Firebase Perf Plugins dependency. In your projects `android/build.gradle` file, add the plugin to your dependencies:
 
 ```groovy
 dependencies {
   // ...
-  classpath 'com.google.firebase:firebase-plugins:{{ android.firebase.plugins }}'
+  classpath 'com.google.firebase:perf-plugin:{{ android.firebase.plugins }}'
 }
 ```
+
+!> Warning: the plugin dependency changed to `perf-plugin` from `firebase-plugins` with the move to version 1.2. You must update your `android/build.gradle` to use it.
 
 At the top of your `android/app/build.gradle` file, below other plugins, apply the `firebase-perf` plugin:
 

--- a/docs/releases/v5.4.x.md
+++ b/docs/releases/v5.4.x.md
@@ -1,22 +1,51 @@
 # v5.4.x Releases
 
+!> **BREAKING CHANGE NOTICE: v5.x.x will allow breaking changes in the _minor_ version number**
+
+> *This semver policy change will begin with v5.5.0*
+>
+> The patch version will not allow breaking change
+>
+> Patch releases will contain bugfixes and necessary features required for Firebase SDK compatibility, but occasionally the underlying Firebase SDKs or React-Native ecosystem require breaking change in order for v5.x.x to stay relevant during the v5.x.x -> v6 transition.
+>
+> Adjust your `package.json` to use the `~` semver range specifier vs `^` to avoid unexpected breaking change:
+
+ ```json
+  ...
+  "react-native-firebase": "~5.4.0",
+  ...
+```
+
 Install using:
- 
+
 ```bash
 npm install --save react-native-firebase@latest
 ```
 
 > v6 is around the corner(ish), please check out [this issue](https://github.com/invertase/react-native-firebase/issues/2025) to keep up to date with all the changes coming as part of v6.
 
-## 5.4.0
+## Changelog
 
-### Change Log
+### Unreleased
+
+- **Added breaking change notice. v5.5.x will begin to allow breaking change in minor releases**
+- Updated documented versions of Firebase SDK dependencies
+
+## 5.4.2
+
+5.4.1 had build/deploy issues, 5.4.2 was released to correct them. No changes from 5.4.1
+
+## 5.4.1
+
+- [JS][FEATURE][FIRESTORE] - Implement isEqual in Query :fire: [#2174](https://github.com/invertase/react-native-firebase/pull/2174)
+
+## 5.4.0
 
  - This is mainly a release to upgrade the Android Firebase SDK dependencies to address several native SDK bugs ([#2122](https://github.com/invertase/react-native-firebase/issues/2122)).
  
 > Special thanks to [@mikehardy](https://github.com/mikehardy) for spending a significant amount of time getting our tests build and CI working on Android again, this was blocking v5.x.x releases. [#2166](https://github.com/invertase/react-native-firebase/pull/2166)
  
-#### Enhancements
+### Enhancements
  
  - [ENHANCEMENT] [FIRESTORE] - Implement `isEqual` support in `CollectionReference` (#2077)
    
@@ -29,7 +58,7 @@ npm install --save react-native-firebase@latest
  
 ----
 
-### Upgrade instructions
+## Upgrade instructions
 
 ```
 npm install --save react-native-firebase@latest
@@ -80,25 +109,25 @@ classpath 'com.google.gms:google-services:4.2.0'
 
 > These versions are the same as v5.3.x - you don't need to change anything if upgrading from v5.3.x
 
-v5.4.0 supports iOS SDK version `5.19.0` and above; however it's recommended to update to `v5.20.1` and lock the versions specifically in your `Podfile`:
+v5.4.0 supports iOS SDK version `5.19.0` and above; however it's recommended to update to `v5.20.2` and lock the versions specifically in your `Podfile`:
 
 ```ruby
-  pod 'Firebase/AdMob', '~> 5.20.1'
-  pod 'Firebase/Auth', '~> 5.20.1'
-  pod 'Firebase/Core', '~> 5.20.1'
-  pod 'Firebase/Database', '~> 5.20.1'
-  pod 'Firebase/Functions', '~> 5.20.1'
-  pod 'Firebase/DynamicLinks', '~> 5.20.1'
-  pod 'Firebase/Firestore', '~> 5.20.1'
-  pod 'Firebase/Invites', '~> 5.20.1'
-  pod 'Firebase/Messaging', '~> 5.20.1'
-  pod 'Firebase/RemoteConfig', '~> 5.20.1'
-  pod 'Firebase/Storage', '~> 5.20.1'
-  pod 'Firebase/Performance', '~> 5.20.1'
+  pod 'Firebase/AdMob', '~> 5.20.2'
+  pod 'Firebase/Auth', '~> 5.20.2'
+  pod 'Firebase/Core', '~> 5.20.2'
+  pod 'Firebase/Database', '~> 5.20.2'
+  pod 'Firebase/Functions', '~> 5.20.2'
+  pod 'Firebase/DynamicLinks', '~> 5.20.2'
+  pod 'Firebase/Firestore', '~> 5.20.2'
+  pod 'Firebase/Invites', '~> 5.20.2'
+  pod 'Firebase/Messaging', '~> 5.20.2'
+  pod 'Firebase/RemoteConfig', '~> 5.20.2'
+  pod 'Firebase/Storage', '~> 5.20.2'
+  pod 'Firebase/Performance', '~> 5.20.2'
   
   # Crashlytics
-  pod 'Fabric', '~> 1.9.0'
-  pod 'Crashlytics', '~> 3.12.0'
+  pod 'Fabric', '~> 1.10.1'
+  pod 'Crashlytics', '~> 3.13.1'
 ```
 
 ----


### PR DESCRIPTION
The big news here is the breaking change notice for the proposed semver policy change to allow breaks in v5 minor. I explain the reasoning and I've proposed it in a few places with no dissent as yet.

My idea is to get a v5.4.x patch release in shape and release it with some sort of CLI messaging as well (a postinstall echo or however you do it), then commence with v5.5 to get PRs merged that help track with underlying SDKs.

I will try to bridge between v5 and v6 by verifying any underlying SDK tracking work is reflected in v6 as well so straddling the branches is not onerous.

there were some special notes for the perf plugin and admob as the
versions moved

also config.yml::ios|android.fabric.version was unused (grep verified) and lagged the crashlytics version, removed