### PR TITLE
Prepare for 5.4.3 release

### DIFF
--- a/docs/releases/v5.4.x.md
+++ b/docs/releases/v5.4.x.md
@@ -2,15 +2,9 @@
 
 !> **BREAKING CHANGE NOTICE: v5.x.x will allow breaking changes in the _minor_ version number**
 
-> *This semver policy change will begin with v5.5.0*
->
-> The patch version will not allow breaking change
->
-> Patch releases will contain bugfixes and necessary features required for Firebase SDK compatibility, but occasionally the underlying Firebase SDKs or React-Native ecosystem require breaking change in order for v5.x.x to stay relevant during the v5.x.x -> v6 transition.
->
-> Adjust your `package.json` to use the `~` semver range specifier vs `^` to avoid unexpected breaking change:
+> *This semver policy change will begin with v5.5.0*.  The patch version will not allow breaking change. Patch releases will contain bugfixes and necessary features required for Firebase SDK compatibility, but occasionally the underlying Firebase SDKs or React-Native ecosystem require breaking change in order for v5.x.x to stay relevant during the v5.x.x -> v6 transition. Adjust your `package.json` to use the `~` semver range specifier vs `^` to avoid unexpected breaking change:
 
- ```json
+```json
   ...
   "react-native-firebase": "~5.4.0",
   ...
@@ -26,10 +20,15 @@ npm install --save react-native-firebase@latest
 
 ## Changelog
 
-### Unreleased
+## 5.4.3
 
-- **Added breaking change notice. v5.5.x will begin to allow breaking change in minor releases**
-- Updated documented versions of Firebase SDK dependencies
+> **Added breaking change notice. v5.5.x will begin to allow breaking change in *minor* releases**
+
+- [IOS][BUGFIX]LINKS] Update linking restorationHandler for iOS12 (https://github.com/invertase/react-native-firebase/pull/2216)
+- [FIRESTORE][FEATURE][cacheSizeBytes]: expose SDK cacheSizeBytes (https://github.com/invertase/react-native-firebase/pull/2203)
+- [TYPESCRIPT][FIX][functions] constructor type for setting functions region or app (https://github.com/invertase/react-native-firebase/pull/2131)
+- [ENHANCEMENT][CRASHLYTICS] add recordCustomError/setUserName/setUserEmail (https://github.com/invertase/react-native-firebase/pull/1940)
+- [ANDROID][BUGFIX][ADMOB] Fix Admob crash from UnityAds with Admob Mediation (https://github.com/invertase/react-native-firebase/pull/-892)
 
 ## 5.4.2
 
@@ -41,32 +40,32 @@ npm install --save react-native-firebase@latest
 
 ## 5.4.0
 
- - This is mainly a release to upgrade the Android Firebase SDK dependencies to address several native SDK bugs ([#2122](https://github.com/invertase/react-native-firebase/issues/2122)).
- 
+- This is mainly a release to upgrade the Android Firebase SDK dependencies to address several native SDK bugs ([#2122](https://github.com/invertase/react-native-firebase/issues/2122)).
+
 > Special thanks to [@mikehardy](https://github.com/mikehardy) for spending a significant amount of time getting our tests build and CI working on Android again, this was blocking v5.x.x releases. [#2166](https://github.com/invertase/react-native-firebase/pull/2166)
- 
+
 ### Enhancements
- 
- - [ENHANCEMENT] [FIRESTORE] - Implement `isEqual` support in `CollectionReference` (#2077)
-   
+
+- [ENHANCEMENT] [FIRESTORE] - Implement `isEqual` support in `CollectionReference` (#2077)
+
 ### Other
 
- - [TYPES] [BUGFIX] [AUTHENTICATION] - Change type `PhoneAuthSnapshot.Error` to `NativeError` (#2090)
- - [ANDROID] [BUGFIX] [MESSAGING] - Add null checks to avoid accidentally acquiring wake locks on Android. (#2092)
- - [ANDROID] [BUGFIX] [STORAGE] - Preserve `file://` prefix (#2111)
- - [ANDROID] [INTERNALS] rework internals serialization utils to better support `JSONObject`/`Array` values
- 
+- [TYPES] [BUGFIX] [AUTHENTICATION] - Change type `PhoneAuthSnapshot.Error` to `NativeError` (#2090)
+- [ANDROID] [BUGFIX] [MESSAGING] - Add null checks to avoid accidentally acquiring wake locks on Android. (#2092)
+- [ANDROID] [BUGFIX] [STORAGE] - Preserve `file://` prefix (#2111)
+- [ANDROID] [INTERNALS] rework internals serialization utils to better support `JSONObject`/`Array` values
+
 ----
 
 ## Upgrade instructions
 
-```
+```shell
 npm install --save react-native-firebase@latest
 ```
 
 ----
 
-#### Android - Update Dependencies
+### Android - Update Dependencies
 
 1) In `android/app/build.gradle`, update all the firebase and gms dependencies to the following versions:
 
@@ -103,6 +102,7 @@ classpath 'com.android.tools.build:gradle:3.3.2'
 classpath 'com.google.gms:google-services:4.2.0'
 // ...
 ```
+
 ----
 
 #### iOS - Update Firebase SDKs
@@ -145,5 +145,5 @@ Thank to [all the contributors](https://github.com/invertase/react-native-fireba
 If you'd like to contribute please check out our [testing](https://rnfirebase.io/docs/v5.x.x/testing) and [contributing](https://rnfirebase.io/docs/v5.x.x/contributing) guides.
 
 ## Other Releases
-        
+
 [View other releases.](/docs/v5.x.x/release-notes)

--- a/docs/releases/v5.4.x.md
+++ b/docs/releases/v5.4.x.md
@@ -27,7 +27,6 @@ npm install --save react-native-firebase@latest
 - [IOS][BUGFIX]LINKS] Update linking restorationHandler for iOS12 (https://github.com/invertase/react-native-firebase/pull/2216)
 - [FIRESTORE][FEATURE][cacheSizeBytes]: expose SDK cacheSizeBytes (https://github.com/invertase/react-native-firebase/pull/2203)
 - [TYPESCRIPT][FIX][functions] constructor type for setting functions region or app (https://github.com/invertase/react-native-firebase/pull/2131)
-- [ENHANCEMENT][CRASHLYTICS] add recordCustomError/setUserName/setUserEmail (https://github.com/invertase/react-native-firebase/pull/1940)
 - [ANDROID][BUGFIX][ADMOB] Fix Admob crash from UnityAds with Admob Mediation (https://github.com/invertase/react-native-firebase/pull/-892)
 
 ## 5.4.2


### PR DESCRIPTION
Sorry for being change-y on the whitespace in this file, I delinted it at the same time. If you look at it with no whitespace it's clean.

This is I think the full list of changes merged in since 5.4.2, formatted I hope correctly, and I hope easy and ready to go

I think everything is in shape for a 5.4.3 release after the breaking change notice on npm install is approved-by-not-me-the-author and merged-by-anyone: https://github.com/invertase/react-native-firebase/pull/2214 