### PR TITLE
fix formatting on 5.4.x release notes

### DIFF
--- a/docs/releases/v5.4.x.md
+++ b/docs/releases/v5.4.x.md
@@ -2,52 +2,49 @@
 
 !> **BREAKING CHANGE NOTICE: v5.x.x will allow breaking changes in the _minor_ version number**
 
-> *This semver policy change will begin with v5.5.0*.  The patch version will not allow breaking change. Patch releases will contain bugfixes and necessary features required for Firebase SDK compatibility, but occasionally the underlying Firebase SDKs or React-Native ecosystem require breaking change in order for v5.x.x to stay relevant during the v5.x.x -> v6 transition. Adjust your `package.json` to use the `~` semver range specifier vs `^` to avoid unexpected breaking change:
+> *This semver policy change will begin with v5.5.0*.  The patch version will not allow breaking change. Patch releases will contain bugfixes and necessary features required for Firebase SDK compatibility, but occasionally the underlying Firebase SDKs or React-Native ecosystem require breaking change in order for v5 to stay relevant during the v5 -> v6 transition. Adjust your `package.json` to use the `~` semver range specifier vs `^` to avoid unexpected breaking specify the dependency like this and alter the minor version as it suits your project:
 
-```json
-  ...
-  "react-native-firebase": "~5.4.0",
-  ...
-```
 
-Install using:
+`"react-native-firebase": "~5.4.0"`
+
+You may install the current version using:
 
 ```bash
-npm install --save react-native-firebase@latest
+npm install --save react-native-firebase@~latest
 ```
 
 > v6 is around the corner(ish), please check out [this issue](https://github.com/invertase/react-native-firebase/issues/2025) to keep up to date with all the changes coming as part of v6.
 
 ## Changelog
 
-## 5.4.3
+### 5.4.3
 
 > **Added breaking change notice. v5.5.x will begin to allow breaking change in *minor* releases**
 
 - [IOS][BUGFIX]LINKS] Update linking restorationHandler for iOS12 (https://github.com/invertase/react-native-firebase/pull/2216)
 - [FIRESTORE][FEATURE][cacheSizeBytes]: expose SDK cacheSizeBytes (https://github.com/invertase/react-native-firebase/pull/2203)
 - [TYPESCRIPT][FIX][functions] constructor type for setting functions region or app (https://github.com/invertase/react-native-firebase/pull/2131)
-- [ANDROID][BUGFIX][ADMOB] Fix Admob crash from UnityAds with Admob Mediation (https://github.com/invertase/react-native-firebase/pull/-892)
+- [ANDROID][BUGFIX][ADMOB] Fix Admob crash from UnityAds with Admob Mediation (https://github.com/invertase/react-native-firebase/pull/1892)
 
-## 5.4.2
+### 5.4.2
 
 5.4.1 had build/deploy issues, 5.4.2 was released to correct them. No changes from 5.4.1
 
-## 5.4.1
+### 5.4.1
 
 - [JS][FEATURE][FIRESTORE] - Implement isEqual in Query :fire: [#2174](https://github.com/invertase/react-native-firebase/pull/2174)
 
-## 5.4.0
+### 5.4.0
 
 - This is mainly a release to upgrade the Android Firebase SDK dependencies to address several native SDK bugs ([#2122](https://github.com/invertase/react-native-firebase/issues/2122)).
 
 > Special thanks to [@mikehardy](https://github.com/mikehardy) for spending a significant amount of time getting our tests build and CI working on Android again, this was blocking v5.x.x releases. [#2166](https://github.com/invertase/react-native-firebase/pull/2166)
 
-### Enhancements
+#### Enhancements
 
 - [ENHANCEMENT] [FIRESTORE] - Implement `isEqual` support in `CollectionReference` (#2077)
 
-### Other
+#### Other
 
 - [TYPES] [BUGFIX] [AUTHENTICATION] - Change type `PhoneAuthSnapshot.Error` to `NativeError` (#2090)
 - [ANDROID] [BUGFIX] [MESSAGING] - Add null checks to avoid accidentally acquiring wake locks on Android. (#2092)
@@ -104,7 +101,7 @@ classpath 'com.google.gms:google-services:4.2.0'
 
 ----
 
-#### iOS - Update Firebase SDKs
+### iOS - Update Firebase SDKs
 
 > These versions are the same as v5.3.x - you don't need to change anything if upgrading from v5.3.x
 


### PR DESCRIPTION
I had an incorrect PR URL for the AdMob fix

but more importantly something is terribly wrong with the formatting on the published release notes and I'm not sure what as it previews correctly in VSCode

I made some changes I think will fix it as it renders on rnfirebase.io but the goal here is for this page to look normal: https://rnfirebase.io/docs/v5.x.x/releases/v5.4.x

If you could approve and merge it then look at the actual page - if it doesn't look right then I don't know how to fix it as the markdown rendering is different than I'm expecting, and I'll need help