### PR TITLE
fix formatting, add v5.5.x compatibility matrix, document patch releases

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -52,11 +52,11 @@ We provide several options for you to get started with React Native Firebase, se
 
 > The table below shows the supported versions of React Native and the Firebase SDKs for different versions of `react-native-firebase`
 
-|                           |  3.3.x   |       5.2.x        |       5.4.x       |
-| ------------------------- | :------: | :----------------: | :---------------: |
-| React Native              | 0.50-52  |      0.52-58       |      ^0.59.3      |
-| Play Services Android SDK | 11.8.0 + |      ^16.1.0       |      ^16.1.0      |
-| Firebase iOS SDK          | 4.7.0 +  |  ^5.10.x -^5.18.x  | ^5.19.x - ^5.20.x |
+|                           |  3.3.x   |       5.2.x        |       5.4.x       |    5.5.x   |
+| ------------------------- | :------: | :----------------: | :---------------: |:----------:|
+| React Native              | 0.50-52  |      0.52-58       |      ^0.59.3      |   ^0.59.3  |
+| Play Services Android SDK | 11.8.0 + |      ^16.1.0       |      ^16.1.0      |  ^16.1.0 (or ^17.x via [jetifier](https://github.com/mikehardy/jetifier) |
+| Firebase iOS SDK          | 4.7.0 +  |  ^5.10.x -^5.18.x  | ^5.19.x - ^5.20.x | ^5.19.x - ^6.2.x |
 
 ## Questions
 

--- a/docs/releases/v5.5.x.md
+++ b/docs/releases/v5.5.x.md
@@ -24,6 +24,18 @@ Upgrade instructions are below.
 
 ## Changelog
 
+### 5.5.3
+
+- [BUGFIX][LINKS][domainURIPrefix] - correctly pass domainURIPrefix Fixes #2262
+
+### 5.5.2
+
+- [BUGFIX][COMPILE][ANALYTICS] - conform to new config API location, Fixes #2259
+
+### 5.5.1
+
+- [IOS][BUGFIX][CRASHLYTICS] - fix crashlytics pod integration and compile, Fixes #2256
+
 ### 5.5.0
 
 !> **BREAKING CHANGES** This release updates the Firebase SDKs to current versions, including their underlying breaking changes
@@ -71,6 +83,8 @@ npm install --save react-native-firebase@latest
 - **com.google.firebase:firebase-perf**:{{ android.firebase.perf }}
 - **com.google.firebase:firebase-storage**:{{ android.firebase.storage }}
 - **com.crashlytics.sdk.android:crashlytics**:{{ android.firebase.crashlytics }}
+
+Note that you may be able to use the AndroidX versions with [jetifier](https://github.com/mikehardy/jetifier) - it appears to be tested and working but is not directly supported.
 
 2) Ensure you're using gradle build tools 3.3.2 or higher (untested above 4.0.0)
 

--- a/docs/releases/v5.5.x.md
+++ b/docs/releases/v5.5.x.md
@@ -108,7 +108,7 @@ classpath 'com.google.firebase:perf-plugin:1.2.1'
 // ...
 apply plugin: "com.google.firebase.firebase-perf"
 // ...
-
+```
 
 ----
 


### PR DESCRIPTION
I'll push a release notes page without a formatting error one of these days.
Until then, this should fix the v5.5.x page

This also adds the point releases from overnight and this morning, and updates the compatibility chart