### PR TITLE
Android Messaging - Fix installation link on receiving messages

### DIFF
--- a/docs/messaging/receiving-messages.md
+++ b/docs/messaging/receiving-messages.md
@@ -86,7 +86,7 @@ To allow this to work, we make use of React Native's built-in [Headless JS](http
 
 ### 1) Add Service to Android Manifest
 
-Firstly, check that you've followed the optional steps in the [Android Installation guide](version /installation/android).
+Firstly, check that you've followed the optional steps in the [Android Installation guide](version /messaging/android).
 
 ### 2) Handle background messages
 


### PR DESCRIPTION
This link was pointing to the wrong "Android Installation" page