### PR TITLE
Fix ios.md

### DIFF
--- a/docs/links/ios.md
+++ b/docs/links/ios.md
@@ -78,7 +78,7 @@ Run `pod update`.
     openURL:(NSURL *)url 
     options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options {
     
-        BOOL handled = [RCTLinkingManager application:application openURL:url sourceApplication:sourceApplication annotation:annotation];
+        BOOL handled = [RCTLinkingManager application:application openURL:url options:options];
         
         if (!handled) {
             handled = [[RNFirebaseLinks instance] application:application openURL:url options:options];


### PR DESCRIPTION
In
```
application:(UIApplication *)application openURL:(NSURL *)url  options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options
```
we couldn't call method below.
```
[RCTLinkingManager application:application openURL:url sourceApplication:sourceApplication annotation:annotation];
```
And I think that calling below is right.
```
[RCTLinkingManager application:application openURL:url options:options];
```