### PR TITLE
Updates to reflect new React Native MainApplication code

### DIFF
--- a/docs/admob/android.md
+++ b/docs/admob/android.md
@@ -15,11 +15,13 @@ dependencies {
 
 ## Install the RNFirebase Admob package
 
+**Note**: This is for react-native 0.60+ - for earlier versions of react-native please refer to the [previous version of this documentation](https://github.com/invertase/react-native-firebase-docs/blob/1659c6ce9503e7ae2db16526e70230b37ef256af/docs/admob/android.md).
+
 Add the `RNFirebaseAdMobPackage` to your `android/app/src/main/java/com/[app name]/MainApplication.java`:
 
 ```java
 // ...
-import io.invertase.firebase.RNFirebasePackage;
+import com.facebook.react.ReactApplication;
 import io.invertase.firebase.admob.RNFirebaseAdMobPackage; // <-- Add this line
 
 public class MainApplication extends Application implements ReactApplication {
@@ -27,11 +29,12 @@ public class MainApplication extends Application implements ReactApplication {
 
     @Override
     protected List<ReactPackage> getPackages() {
-      return Arrays.<ReactPackage>asList(
-          new MainReactPackage(),
-          new RNFirebasePackage(),
-          new RNFirebaseAdMobPackage() // <-- Add this line
-      );
+      @SuppressWarnings("UnnecessaryLocalVariable")
+      List<ReactPackage> packages = new PackageList(this).getPackages();
+      // Packages that cannot be autolinked yet can be added manually here, for example:
+      // packages.add(new MyReactNativePackage());
+      packages.add(new RNFirebaseAdMobPackage()); // <-- Add this line
+      return packages;
     }
   };
   // ...

--- a/docs/analytics/android.md
+++ b/docs/analytics/android.md
@@ -6,11 +6,13 @@ Analytics does not require any other dependencies to work.
 
 ## Install the RNFirebase Analytics package
 
+**Note**: This is for react-native 0.60+ - for earlier versions of react-native please refer to the [previous version of this documentation](https://github.com/invertase/react-native-firebase-docs/blob/7996824f9613a500c3929d3aabd21321337db15c/docs/analytics/android.md).
+
 Add the `RNFirebaseAnalyticsPackage` to your `android/app/src/main/java/com/[app name]/MainApplication.java`:
 
 ```java
 // ...
-import io.invertase.firebase.RNFirebasePackage;
+import com.facebook.react.ReactApplication;
 import io.invertase.firebase.analytics.RNFirebaseAnalyticsPackage; // <-- Add this line
 
 public class MainApplication extends Application implements ReactApplication {
@@ -18,11 +20,12 @@ public class MainApplication extends Application implements ReactApplication {
 
     @Override
     protected List<ReactPackage> getPackages() {
-      return Arrays.<ReactPackage>asList(
-          new MainReactPackage(),
-          new RNFirebasePackage(),
-          new RNFirebaseAnalyticsPackage() // <-- Add this line
-      );
+      @SuppressWarnings("UnnecessaryLocalVariable")
+      List<ReactPackage> packages = new PackageList(this).getPackages();
+      // Packages that cannot be autolinked yet can be added manually here, for example:
+      // packages.add(new MyReactNativePackage());
+      packages.add(new RNFirebaseAnalyticsPackage()); // <-- Add this line
+      return packages;
     }
   };
   // ...

--- a/docs/auth/android.md
+++ b/docs/auth/android.md
@@ -19,7 +19,7 @@ Add the `RNFirebaseAuthPackage` to your `android/app/src/main/java/com/[app name
 
 ```java
 // ...
-import io.invertase.firebase.RNFirebasePackage;
+import com.facebook.react.ReactApplication;
 import io.invertase.firebase.auth.RNFirebaseAuthPackage; // <-- Add this line
 
 public class MainApplication extends Application implements ReactApplication {
@@ -27,11 +27,12 @@ public class MainApplication extends Application implements ReactApplication {
 
     @Override
     protected List<ReactPackage> getPackages() {
-      return Arrays.<ReactPackage>asList(
-          new MainReactPackage(),
-          new RNFirebasePackage(),
-          new RNFirebaseAuthPackage() // <-- Add this line
-      );
+      @SuppressWarnings("UnnecessaryLocalVariable")
+      List<ReactPackage> packages = new PackageList(this).getPackages();
+      // Packages that cannot be autolinked yet can be added manually here, for example:
+      // packages.add(new MyReactNativePackage());
+      packages.add(new RNFirebaseAuthPackage()); <-- Add this line
+      return packages;
     }
   };
   // ...

--- a/docs/auth/android.md
+++ b/docs/auth/android.md
@@ -15,7 +15,7 @@ dependencies {
 
 ## Install the RNFirebase Authentication package
 
-**Note**: This is for React Native 6.0+ - for earlier versions of RN please refer to the [previous version of this documentation](https://github.com/invertase/react-native-firebase-docs/blob/8c36d9df1a35e993f5d4126c33448256b9c5b682/docs/auth/android.md).
+**Note**: This is for react-native 0.60+ - for earlier versions of react-native please refer to the [previous version of this documentation](https://github.com/invertase/react-native-firebase-docs/blob/8c36d9df1a35e993f5d4126c33448256b9c5b682/docs/auth/android.md).
 
 Add the `RNFirebaseAuthPackage` to your `android/app/src/main/java/com/[app name]/MainApplication.java`:
 

--- a/docs/auth/android.md
+++ b/docs/auth/android.md
@@ -15,6 +15,8 @@ dependencies {
 
 ## Install the RNFirebase Authentication package
 
+**Note**: This is for React Native 6.0+ - for earlier versions of RN please refer to the [previous version of this documentation](https://github.com/invertase/react-native-firebase-docs/blob/8c36d9df1a35e993f5d4126c33448256b9c5b682/docs/auth/android.md).
+
 Add the `RNFirebaseAuthPackage` to your `android/app/src/main/java/com/[app name]/MainApplication.java`:
 
 ```java
@@ -31,7 +33,7 @@ public class MainApplication extends Application implements ReactApplication {
       List<ReactPackage> packages = new PackageList(this).getPackages();
       // Packages that cannot be autolinked yet can be added manually here, for example:
       // packages.add(new MyReactNativePackage());
-      packages.add(new RNFirebaseAuthPackage()); <-- Add this line
+      packages.add(new RNFirebaseAuthPackage()); // <-- Add this line
       return packages;
     }
   };

--- a/docs/config/android.md
+++ b/docs/config/android.md
@@ -15,11 +15,13 @@ dependencies {
 
 ## Install the RNFirebase Remote Config package
 
+**Note**: This is for react-native 0.60+ - for earlier versions of react-native please refer to the [previous version of this documentation](https://github.com/invertase/react-native-firebase-docs/blob/c974d5253f85cec0a82081a086c5d9dff50c55ad/docs/config/android.md).
+
 Add the `RNFirebaseRemoteConfigPackage` to your `android/app/src/main/java/com/[app name]/MainApplication.java`:
 
 ```java
 // ...
-import io.invertase.firebase.RNFirebasePackage;
+import com.facebook.react.ReactApplication;
 import io.invertase.firebase.config.RNFirebaseRemoteConfigPackage; // <-- Add this line
 
 public class MainApplication extends Application implements ReactApplication {
@@ -27,11 +29,12 @@ public class MainApplication extends Application implements ReactApplication {
 
     @Override
     protected List<ReactPackage> getPackages() {
-      return Arrays.<ReactPackage>asList(
-          new MainReactPackage(),
-          new RNFirebasePackage(),
-          new RNFirebaseRemoteConfigPackage() // <-- Add this line
-      );
+      @SuppressWarnings("UnnecessaryLocalVariable")
+      List<ReactPackage> packages = new PackageList(this).getPackages();
+      // Packages that cannot be autolinked yet can be added manually here, for example:
+      // packages.add(new MyReactNativePackage());
+      packages.add(new RNFirebaseRemoteConfigPackage()); // <-- Add this line
+      return packages;
     }
   };
   // ...

--- a/docs/crashlytics/android.md
+++ b/docs/crashlytics/android.md
@@ -53,11 +53,13 @@ apply plugin: "io.fabric"
 
 ## Install the RNFirebase Crashlytics package
 
+**Note**: This is for react-native 0.60+ - for earlier versions of react-native please refer to the [previous version of this documentation](https://github.com/invertase/react-native-firebase-docs/blob/bbb35f90a7b6280591caf7ffb072a2619724d829/docs/crashlytics/android.md).
+
 Add the `RNFirebaseCrashlyticsPackage` to your `android/app/src/main/java/com/[app name]/MainApplication.java`:
 
 ```java
 // ...
-import io.invertase.firebase.RNFirebasePackage;
+import com.facebook.react.ReactApplication;
 import io.invertase.firebase.fabric.crashlytics.RNFirebaseCrashlyticsPackage; // <-- Add this line
 
 public class MainApplication extends Application implements ReactApplication {
@@ -65,11 +67,12 @@ public class MainApplication extends Application implements ReactApplication {
 
     @Override
     protected List<ReactPackage> getPackages() {
-      return Arrays.<ReactPackage>asList(
-          new MainReactPackage(),
-          new RNFirebasePackage(),
-          new RNFirebaseCrashlyticsPackage() // <-- Add this line
-      );
+      @SuppressWarnings("UnnecessaryLocalVariable")
+      List<ReactPackage> packages = new PackageList(this).getPackages();
+      // Packages that cannot be autolinked yet can be added manually here, for example:
+      // packages.add(new MyReactNativePackage());
+      packages.add(new RNFirebaseCrashlyticsPackage()); // <-- Add this line
+      return packages;
     }
   };
   // ...

--- a/docs/database/android.md
+++ b/docs/database/android.md
@@ -13,11 +13,13 @@ dependencies {
 
 ## Install the RNFirebase Database package
 
+**Note**: This is for react-native 0.60+ - for earlier versions of react-native please refer to the [previous version of this documentation](https://github.com/invertase/react-native-firebase-docs/blob/cfe8802662b0de36f5f0ad083a0c7472319629ba/docs/database/android.md).
+
 Add the `RNFirebaseDatabasePackage` to your `android/app/src/main/java/com/[app name]/MainApplication.java`:
 
 ```java
 // ...
-import io.invertase.firebase.RNFirebasePackage;
+import com.facebook.react.ReactApplication;
 import io.invertase.firebase.database.RNFirebaseDatabasePackage; // <-- Add this line
 
 public class MainApplication extends Application implements ReactApplication {
@@ -25,11 +27,12 @@ public class MainApplication extends Application implements ReactApplication {
 
     @Override
     protected List<ReactPackage> getPackages() {
-      return Arrays.<ReactPackage>asList(
-          new MainReactPackage(),
-          new RNFirebasePackage(),
-          new RNFirebaseDatabasePackage() // <-- Add this line
-      );
+      @SuppressWarnings("UnnecessaryLocalVariable")
+      List<ReactPackage> packages = new PackageList(this).getPackages();
+      // Packages that cannot be autolinked yet can be added manually here, for example:
+      // packages.add(new MyReactNativePackage());
+      packages.add(new RNFirebaseDatabasePackage()); // <-- Add this line
+      return packages;
     }
   };
   // ...

--- a/docs/firestore/android.md
+++ b/docs/firestore/android.md
@@ -15,11 +15,13 @@ dependencies {
 
 ## Install the RNFirebase Firestore package
 
+**Note**: This is for react-native 0.60+ - for earlier versions of react-native please refer to the [previous version of this documentation](https://github.com/invertase/react-native-firebase-docs/blob/ba1f39d6099ea384cb17ec9cc4a319e41e45154b/firestore/auth/android.md).
+
 Add the `RNFirebaseFirestorePackage` to your `android/app/src/main/java/com/[app name]/MainApplication.java`:
 
 ```java
 // ...
-import io.invertase.firebase.RNFirebasePackage;
+import com.facebook.react.ReactApplication;
 import io.invertase.firebase.firestore.RNFirebaseFirestorePackage; // <-- Add this line
 
 public class MainApplication extends Application implements ReactApplication {
@@ -27,11 +29,12 @@ public class MainApplication extends Application implements ReactApplication {
 
     @Override
     protected List<ReactPackage> getPackages() {
-      return Arrays.<ReactPackage>asList(
-          new MainReactPackage(),
-          new RNFirebasePackage(),
-          new RNFirebaseFirestorePackage() // <-- Add this line
-      );
+      @SuppressWarnings("UnnecessaryLocalVariable")
+      List<ReactPackage> packages = new PackageList(this).getPackages();
+      // Packages that cannot be autolinked yet can be added manually here, for example:
+      // packages.add(new MyReactNativePackage());
+      packages.add(new RNFirebaseFirestorePackage()); // <-- Add this line
+      return packages;
     }
   };
   // ...

--- a/docs/firestore/android.md
+++ b/docs/firestore/android.md
@@ -15,7 +15,7 @@ dependencies {
 
 ## Install the RNFirebase Firestore package
 
-**Note**: This is for react-native 0.60+ - for earlier versions of react-native please refer to the [previous version of this documentation](https://github.com/invertase/react-native-firebase-docs/blob/ba1f39d6099ea384cb17ec9cc4a319e41e45154b/firestore/auth/android.md).
+**Note**: This is for react-native 0.60+ - for earlier versions of react-native please refer to the [previous version of this documentation](https://github.com/invertase/react-native-firebase-docs/blob/ba1f39d6099ea384cb17ec9cc4a319e41e45154b/docs/firestore/android.md).
 
 Add the `RNFirebaseFirestorePackage` to your `android/app/src/main/java/com/[app name]/MainApplication.java`:
 

--- a/docs/functions/android.md
+++ b/docs/functions/android.md
@@ -15,11 +15,13 @@ dependencies {
 
 ## Install the RNFirebase Functions package
 
+**Note**: This is for react-native 0.60+ - for earlier versions of react-native please refer to the [previous version of this documentation](https://github.com/invertase/react-native-firebase-docs/blob/3e9506da2ad058a77a84a5476a057492ffd64a64/docs/functions/android.md).
+
 Add the `RNFirebaseFunctionsPackage` to your `android/app/src/main/java/com/[app name]/MainApplication.java`:
 
 ```java
 // ...
-import io.invertase.firebase.RNFirebasePackage;
+import com.facebook.react.ReactApplication;
 import io.invertase.firebase.functions.RNFirebaseFunctionsPackage; // <-- Add this line
 
 public class MainApplication extends Application implements ReactApplication {
@@ -27,11 +29,12 @@ public class MainApplication extends Application implements ReactApplication {
 
     @Override
     protected List<ReactPackage> getPackages() {
-      return Arrays.<ReactPackage>asList(
-          new MainReactPackage(),
-          new RNFirebasePackage(),
-          new RNFirebaseFunctionsPackage() // <-- Add this line
-      );
+      @SuppressWarnings("UnnecessaryLocalVariable")
+      List<ReactPackage> packages = new PackageList(this).getPackages();
+      // Packages that cannot be autolinked yet can be added manually here, for example:
+      // packages.add(new MyReactNativePackage());
+      packages.add(new RNFirebaseFunctionsPackage()); // <-- Add this line
+      return packages;
     }
   };
   // ...

--- a/docs/iid/android.md
+++ b/docs/iid/android.md
@@ -4,11 +4,13 @@ First ensure you have followed the [initial setup guide](version /installation/i
 
 ## Install the RNFirebase Instance ID package
 
+**Note**: This is for react-native 0.60+ - for earlier versions of react-native please refer to the [previous version of this documentation](https://github.com/invertase/react-native-firebase-docs/blob/b519ea6e892d7068836c40fbd5ddf8fe1dbd7893/docs/iid/android.md).
+
 Add the `RNFirebaseInstanceIdPackage` to your `android/app/src/main/java/com/[app name]/MainApplication.java`:
 
 ```java
 // ...
-import io.invertase.firebase.RNFirebasePackage;
+import com.facebook.react.ReactApplication;
 import io.invertase.firebase.instanceid.RNFirebaseInstanceIdPackage; // <-- Add this line
 
 public class MainApplication extends Application implements ReactApplication {
@@ -16,11 +18,12 @@ public class MainApplication extends Application implements ReactApplication {
 
     @Override
     protected List<ReactPackage> getPackages() {
-      return Arrays.<ReactPackage>asList(
-          new MainReactPackage(),
-          new RNFirebasePackage(),
-          new RNFirebaseInstanceIdPackage() // <-- Add this line
-      );
+      @SuppressWarnings("UnnecessaryLocalVariable")
+      List<ReactPackage> packages = new PackageList(this).getPackages();
+      // Packages that cannot be autolinked yet can be added manually here, for example:
+      // packages.add(new MyReactNativePackage());
+      packages.add(new RNFirebaseInstanceIdPackage()); // <-- Add this line
+      return packages;
     }
   };
   // ...

--- a/docs/invites/android.md
+++ b/docs/invites/android.md
@@ -15,11 +15,13 @@ $ keytool -exportcert -list -v -alias androiddebugkey -keystore ~/.android/debug
 
 ## Install the RNFirebase Invites package
 
+**Note**: This is for react-native 0.60+ - for earlier versions of react-native please refer to the [previous version of this documentation](https://github.com/invertase/react-native-firebase-docs/blob/a02587befebb0513da8d662cc7ea5f435947e2e8/docs/invites/android.md).
+
 Add the `RNFirebaseInvitesPackage` to your `android/app/src/main/java/com/[app name]/MainApplication.java`:
 
 ```java
 // ...
-import io.invertase.firebase.RNFirebasePackage;
+import com.facebook.react.ReactApplication;
 import io.invertase.firebase.invites.RNFirebaseInvitesPackage; // <-- Add this line
 
 public class MainApplication extends Application implements ReactApplication {
@@ -27,11 +29,12 @@ public class MainApplication extends Application implements ReactApplication {
 
     @Override
     protected List<ReactPackage> getPackages() {
-      return Arrays.<ReactPackage>asList(
-          new MainReactPackage(),
-          new RNFirebasePackage(),
-          new RNFirebaseInvitesPackage() // <-- Add this line
-      );
+      @SuppressWarnings("UnnecessaryLocalVariable")
+      List<ReactPackage> packages = new PackageList(this).getPackages();
+      // Packages that cannot be autolinked yet can be added manually here, for example:
+      // packages.add(new MyReactNativePackage());
+      packages.add(new RNFirebaseInvitesPackage()); // <-- Add this line
+      return packages;
     }
   };
   // ...

--- a/docs/links/android.md
+++ b/docs/links/android.md
@@ -13,11 +13,13 @@ dependencies {
 
 ## Install the RNFirebase Links package
 
+**Note**: This is for react-native 0.60+ - for earlier versions of react-native please refer to the [previous version of this documentation](https://github.com/invertase/react-native-firebase-docs/blob/cfe8802662b0de36f5f0ad083a0c7472319629ba/docs/links/android.md).
+
 Add the `RNFirebaseLinksPackage` to your `android/app/src/main/java/com/[app name]/MainApplication.java`:
 
 ```java
 // ...
-import io.invertase.firebase.RNFirebasePackage;
+import com.facebook.react.ReactApplication;
 import io.invertase.firebase.links.RNFirebaseLinksPackage; // <-- Add this line
 
 public class MainApplication extends Application implements ReactApplication {
@@ -25,11 +27,12 @@ public class MainApplication extends Application implements ReactApplication {
 
     @Override
     protected List<ReactPackage> getPackages() {
-      return Arrays.<ReactPackage>asList(
-          new MainReactPackage(),
-          new RNFirebasePackage(),
-          new RNFirebaseLinksPackage() // <-- Add this line
-      );
+      @SuppressWarnings("UnnecessaryLocalVariable")
+      List<ReactPackage> packages = new PackageList(this).getPackages();
+      // Packages that cannot be autolinked yet can be added manually here, for example:
+      // packages.add(new MyReactNativePackage());
+      packages.add(new RNFirebaseLinksPackage()); // <-- Add this line
+      return packages;
     }
   };
   // ...

--- a/docs/messaging/android.md
+++ b/docs/messaging/android.md
@@ -16,11 +16,13 @@ dependencies {
 
 ## Install the RNFirebase Messaging package
 
+**Note**: This is for react-native 0.60+ - for earlier versions of react-native please refer to the [previous version of this documentation](https://github.com/invertase/react-native-firebase-docs/blob/2d4382ed1d2aaa939f01851fd909e88f8dc0a632/docs/messaging/android.md).
+
 Add the `RNFirebaseMessagingPackage` to your `android/app/src/main/java/com/[app name]/MainApplication.java`:
 
 ```java
 // ...
-import io.invertase.firebase.RNFirebasePackage;
+import com.facebook.react.ReactApplication;
 import io.invertase.firebase.messaging.RNFirebaseMessagingPackage; // <-- Add this line
 
 public class MainApplication extends Application implements ReactApplication {
@@ -28,11 +30,12 @@ public class MainApplication extends Application implements ReactApplication {
 
     @Override
     protected List<ReactPackage> getPackages() {
-      return Arrays.<ReactPackage>asList(
-          new MainReactPackage(),
-          new RNFirebasePackage(),
-          new RNFirebaseMessagingPackage() // <-- Add this line
-      );
+      @SuppressWarnings("UnnecessaryLocalVariable")
+      List<ReactPackage> packages = new PackageList(this).getPackages();
+      // Packages that cannot be autolinked yet can be added manually here, for example:
+      // packages.add(new MyReactNativePackage());
+      packages.add(new RNFirebaseMessagingPackage()); // <-- Add this line
+      return packages;
     }
   };
   // ...

--- a/docs/notifications/android.md
+++ b/docs/notifications/android.md
@@ -6,11 +6,13 @@ First ensure you have followed the [initial setup guide](version /installation/i
 
 ## Install the RNFirebase Notifications package
 
+**Note**: This is for react-native 0.60+ - for earlier versions of react-native please refer to the [previous version of this documentation](https://github.com/invertase/react-native-firebase-docs/blob/c73145088de14ede089fdd3bd3eaf156cc01203c/docs/auth/android.md).
+
 Add the `RNFirebaseNotificationsPackage` to your `android/app/src/main/java/com/[app name]/MainApplication.java`:
 
 ```java
 // ...
-import io.invertase.firebase.RNFirebasePackage;
+import com.facebook.react.ReactApplication;
 import io.invertase.firebase.notifications.RNFirebaseNotificationsPackage; // <-- Add this line
 
 public class MainApplication extends Application implements ReactApplication {
@@ -18,11 +20,12 @@ public class MainApplication extends Application implements ReactApplication {
 
     @Override
     protected List<ReactPackage> getPackages() {
-      return Arrays.<ReactPackage>asList(
-          new MainReactPackage(),
-          new RNFirebasePackage(),
-          new RNFirebaseNotificationsPackage() // <-- Add this line
-      );
+      @SuppressWarnings("UnnecessaryLocalVariable")
+      List<ReactPackage> packages = new PackageList(this).getPackages();
+      // Packages that cannot be autolinked yet can be added manually here, for example:
+      // packages.add(new MyReactNativePackage());
+      packages.add(new RNFirebaseNotificationsPackage()); // <-- Add this line
+      return packages;
     }
   };
   // ...

--- a/docs/notifications/android.md
+++ b/docs/notifications/android.md
@@ -6,7 +6,7 @@ First ensure you have followed the [initial setup guide](version /installation/i
 
 ## Install the RNFirebase Notifications package
 
-**Note**: This is for react-native 0.60+ - for earlier versions of react-native please refer to the [previous version of this documentation](https://github.com/invertase/react-native-firebase-docs/blob/c73145088de14ede089fdd3bd3eaf156cc01203c/docs/auth/android.md).
+**Note**: This is for react-native 0.60+ - for earlier versions of react-native please refer to the [previous version of this documentation](https://github.com/invertase/react-native-firebase-docs/blob/c73145088de14ede089fdd3bd3eaf156cc01203c/docs/notifications/android.md).
 
 Add the `RNFirebaseNotificationsPackage` to your `android/app/src/main/java/com/[app name]/MainApplication.java`:
 

--- a/docs/perf-mon/android.md
+++ b/docs/perf-mon/android.md
@@ -33,11 +33,13 @@ apply plugin: "com.google.firebase.firebase-perf"
 
 ## Install the RNFirebase Performance package
 
+**Note**: This is for react-native 0.60+ - for earlier versions of react-native please refer to the [previous version of this documentation](https://github.com/invertase/react-native-firebase-docs/blob/0a1f0abcf2fbf16524e61375aa16545a94132739/docs/perf-mon/android.md).
+
 Add the `RNFirebasePerformancePackage` to your `android/app/src/main/java/com/[app name]/MainApplication.java`:
 
 ```java
 // ...
-import io.invertase.firebase.RNFirebasePackage;
+import com.facebook.react.ReactApplication;
 import io.invertase.firebase.perf.RNFirebasePerformancePackage; // <-- Add this line
 
 public class MainApplication extends Application implements ReactApplication {
@@ -45,11 +47,12 @@ public class MainApplication extends Application implements ReactApplication {
 
     @Override
     protected List<ReactPackage> getPackages() {
-      return Arrays.<ReactPackage>asList(
-          new MainReactPackage(),
-          new RNFirebasePackage(),
-          new RNFirebasePerformancePackage() // <-- Add this line
-      );
+      @SuppressWarnings("UnnecessaryLocalVariable")
+      List<ReactPackage> packages = new PackageList(this).getPackages();
+      // Packages that cannot be autolinked yet can be added manually here, for example:
+      // packages.add(new MyReactNativePackage());
+      packages.add(new RNFirebasePerformancePackage()); // <-- Add this line
+      return packages;
     }
   };
   // ...

--- a/docs/storage/android.md
+++ b/docs/storage/android.md
@@ -13,11 +13,13 @@ dependencies {
 
 ## Install the RNFirebase Storage package
 
+**Note**: This is for react-native 0.60+ - for earlier versions of react-native please refer to the [previous version of this documentation](https://github.com/invertase/react-native-firebase-docs/blob/c974d5253f85cec0a82081a086c5d9dff50c55ad/docs/storage/android.md).
+
 Add the `RNFirebaseStoragePackage` to your `android/app/src/main/java/com/[app name]/MainApplication.java`:
 
 ```java
 // ...
-import io.invertase.firebase.RNFirebasePackage;
+import com.facebook.react.ReactApplication;
 import io.invertase.firebase.storage.RNFirebaseStoragePackage; // <-- Add this line
 
 public class MainApplication extends Application implements ReactApplication {
@@ -25,11 +27,12 @@ public class MainApplication extends Application implements ReactApplication {
 
     @Override
     protected List<ReactPackage> getPackages() {
-      return Arrays.<ReactPackage>asList(
-          new MainReactPackage(),
-          new RNFirebasePackage(),
-          new RNFirebaseStoragePackage() // <-- Add this line
-      );
+      @SuppressWarnings("UnnecessaryLocalVariable")
+      List<ReactPackage> packages = new PackageList(this).getPackages();
+      // Packages that cannot be autolinked yet can be added manually here, for example:
+      // packages.add(new MyReactNativePackage());
+      packages.add(new RNFirebaseStoragePackage()); // <-- Add this line
+      return packages;
     }
   };
   // ...


### PR DESCRIPTION
The getPackages method has changed with the latest version of React Native to not include the default firebase package and requires a different way of adding module packages. This updates the documentation for Auth to reflect this. If this PR is approved, I can make this same change across other modules.