### PR TITLE
chore(release notes): Updated all pod versions / compatibility notes

### DIFF
--- a/docs/releases/v5.5.x.md
+++ b/docs/releases/v5.5.x.md
@@ -109,7 +109,7 @@ Note that you may be able to use the AndroidX versions with [jetifier](https://g
 
 ```groovy
 // ...
-classpath 'com.android.tools.build:gradle:3.4.1'
+classpath 'com.android.tools.build:gradle:3.5.0'
 // ...
 ```
 
@@ -119,7 +119,7 @@ classpath 'com.android.tools.build:gradle:3.4.1'
 
 ```groovy
 // ...
-classpath 'com.google.gms:google-services:4.2.0'
+classpath 'com.google.gms:google-services:4.3.1'
 // ...
 ```
 
@@ -129,7 +129,7 @@ classpath 'com.google.gms:google-services:4.2.0'
 
 ```groovy
 // ...
-classpath 'com.google.firebase:perf-plugin:1.2.1'
+classpath 'com.google.firebase:perf-plugin:1.3.1'
 // ...
 ```
 
@@ -147,24 +147,24 @@ apply plugin: "com.google.firebase.firebase-perf"
 
 > These versions are almost all new from 5.4.x
 
-v5.5.x supports iOS SDK version `5.19.0` and above; however it is recommended to update to `v6.2.0` and lock the versions specifically in your `Podfile`:
+v5.5.x supports iOS SDK version `5.19.0` and above; however it is recommended to update to the current version in the `6.x` release series and lock the versions specifically in your `Podfile`. Please note that the goal of v5.5.x+ versions of react-native-firebase is to track the underlying SDKs. So these Pod versions are current when this document was written, but as long as the firebase-ios-sdk release notes (https://firebase.google.com/support/release-notes/ios) don't mention breaking changes in their releases, you should use the most current version. 
 
 ```ruby
-  pod 'Firebase/AdMob', '~> 6.2.0'
-  pod 'Firebase/Auth', '~> 6.2.0'
-  pod 'Firebase/Core', '~> 6.2.0'
-  pod 'Firebase/Database', '~> 6.2.0'
-  pod 'Firebase/Functions', '~> 6.2.0'
-  pod 'Firebase/DynamicLinks', '~> 6.2.0'
-  pod 'Firebase/Firestore', '~> 6.2.0'
-  pod 'Firebase/Messaging', '~> 6.2.0'
-  pod 'Firebase/RemoteConfig', '~> 6.2.0'
-  pod 'Firebase/Storage', '~> 6.2.0'
-  pod 'Firebase/Performance', '~> 6.2.0'
+  pod 'Firebase/AdMob', '~> 6.7.0'
+  pod 'Firebase/Auth', '~> 6.7.0'
+  pod 'Firebase/Core', '~> 6.7.0'
+  pod 'Firebase/Database', '~> 6.7.0'
+  pod 'Firebase/Functions', '~> 6.7.0'
+  pod 'Firebase/DynamicLinks', '~> 6.7.0'
+  pod 'Firebase/Firestore', '~> 6.7.0'
+  pod 'Firebase/Messaging', '~> 6.7.0'
+  pod 'Firebase/RemoteConfig', '~> 6.7.0'
+  pod 'Firebase/Storage', '~> 6.7.0'
+  pod 'Firebase/Performance', '~> 6.7.0'
   
   # Crashlytics
-  pod 'Fabric', '~> 1.10.1'
-  pod 'Crashlytics', '~> 3.13.1'
+  pod 'Fabric', '~> 1.10.2'
+  pod 'Crashlytics', '~> 3.13.3'
 ```
 
 ----


### PR DESCRIPTION
There was some confusion on what version to use in https://github.com/invertase/react-native-firebase/issues/2527#issuecomment-525790238 - this aims to clear it up by mentioning that v5.5.x will work with any non-breaking-change ios sdk release in the 6.x series really