### PR TITLE
docs(versions): update all sdk versions to current

### DIFF
--- a/docs/_config.yaml
+++ b/docs/_config.yaml
@@ -1,43 +1,43 @@
 android:
   build:
-    tools: 3.4.1
+    tools: 3.5.0
   fabric:
     tools: 1.28.1
   firebase:
-    version: 16.0.9
-    ads: 17.2.1
-    analytics: 16.5.0
-    auth: 17.0.0
-    config: 17.0.0
-    core: 16.0.9
-    crashlytics: 2.9.9
-    database: 17.0.0
-    firestore: 19.0.0
-    functions: 17.0.0
-    links: 17.0.0
-    invites: 17.0.0
-    messaging: 18.0.0
-    perf: 17.0.2
-    storage: 17.0.0
-    plugins: 1.2.1
+    version: 17.1.0
+    ads: 18.1.1
+    analytics: 17.1.0
+    auth: 19.0.0
+    config: 19.0.0
+    core: 17.1.0
+    crashlytics: 2.10.1
+    database: 19.0.0
+    firestore: 21.0.0
+    functions: 19.0.0
+    links: 19.0.0
+    invites: 19.0.0
+    messaging: 20.0.0
+    perf: 19.0.0
+    storage: 19.0.0
+    plugins: 1.3.1
   gms:
-    google-services: 4.2.0
+    google-services: 4.3.1
     play-services-base: 16.1.0
 ios:
   fabric:
     tools: 1.10.2
   firebase:
-    ads: 6.3.0
-    auth: 6.3.0
-    config: 6.3.0
-    core: 6.3.0
-    crash: 6.3.0
-    crashlytics: 3.13.2
-    database: 6.3.0
-    firestore: 6.3.0
-    functions: 6.3.0
-    invites: 6.3.0
-    links: 6.3.0
-    messaging: 6.3.0
-    perf: 6.3.0
-    storage: 6.3.0
+    ads: 6.7.0
+    auth: 6.7.0
+    config: 6.7.0
+    core: 6.7.0
+    crash: 6.7.0
+    crashlytics: 3.13.3
+    database: 6.7.0
+    firestore: 6.7.0
+    functions: 6.7.0
+    invites: 6.7.0
+    links: 6.7.0
+    messaging: 6.7.0
+    perf: 6.7.0
+    storage: 6.7.0


### PR DESCRIPTION
This changes all the versions in the config.yaml to the current ones - they are all working with v5.5.6 as far as I know (and I'm using most of them at this point...)