### PR TITLE
Update docs for Android dynamic links: still need invites

### DIFF
--- a/docs/_config.yaml
+++ b/docs/_config.yaml
@@ -14,7 +14,7 @@ android:
     database: 17.0.0
     firestore: 19.0.0
     functions: 17.0.0
-    links: 17.0.0
+    links: 19.0.0
     invites: 17.0.0
     messaging: 18.0.0
     perf: 17.0.2

--- a/docs/links/android.md
+++ b/docs/links/android.md
@@ -7,7 +7,8 @@ Add the Firebase Dynamic Links / Invites dependency to your `android/app/build.g
 ```groovy
 dependencies {
   // ...
-  implementation "com.google.firebase:firebase-dynamic-links:{{ android.firebase.invites }}"
+  implementation "com.google.firebase:firebase-dynamic-links:{{ android.firebase.links }}"
+  implementation "com.google.firebase:firebase-invites:{{ android.firebase.invites }}"
 }
 ```
 


### PR DESCRIPTION
Per title: the docs currently mistakenly omit `com.google.firebase:firebase-invites`: this adds it in

Issue: https://github.com/invertase/react-native-firebase/issues/2528