### PR TITLE
Add warning about [RNFirebaseNotifications configure] placement.

### DIFF
--- a/docs/notifications/ios.md
+++ b/docs/notifications/ios.md
@@ -15,8 +15,11 @@ Add the following import to the top of your `ios/[App Name]/AppDelegate.m`:
 Add the following to the `didFinishLaunchingWithOptions:(NSDictionary *)launchOptions` method, right after `[FIRApp Configure]`:
 
 ```objectivec
+[FIRApp Configure] // after this line
 [RNFirebaseNotifications configure];
 ```
+
+?> It is recommended to add the line within the method **BETWEEN** the statement **[FIRApp Configure]** and the creation of **RCTRootView**. Otherwise the initialization can occur after already being required in your JavaScript code - leading to `app not initialised` exceptions.
 
 Add the following method:
 


### PR DESCRIPTION
I recently fix a bug that was caused by a wrong placement of `[RNFirebaseNotifications configure]`. It was impossible to display notification when the app was in foreground.

One of my team member place it after `RCTRootView`. It took us 6 hours to figure it out.

It is very well specified in the global installation for `[FIRApp configure]`.

I thought it would be a good idea to be more precise here too, even if it is already written just before the code example (but not as visible as for the global installation)