### PR TITLE
Update receiving-notifications.md

### DIFF
--- a/docs/notifications/receiving-notifications.md
+++ b/docs/notifications/receiving-notifications.md
@@ -1,5 +1,7 @@
 # Receiving Notifications
 
+You must call `firebase.messaging().hasPermission()` even if the user has already granted permissions for notifications in order to register the device to receive push notifications.
+
 ## 1) Check permissions
 
 Before you are able to send and receive Notifications, you need to ensure that the user has granted the correct permissions:


### PR DESCRIPTION
For the current latest version (5.x) of RN Firebase, calling `requestPermission` also calls the `registerForRemoteNotifications` method. This is required for the fcm token retrieved to be associated to a valid APNS token, and for push notifications to be delivered correctly to the device. (https://github.com/invertase/react-native-firebase/issues/1203#issuecomment-480549091)

I have been debugging an issue with push notifications and consistently calling the `requestPermission` method even when the user already granted permissions was the only fix.
There is also a `firebase.messaging().ios.registerForRemoteNotifications()` method available, but I found that when I called it from the JS thread, a warning popped up in Xcode saying that this method (the underlying `[RCTSharedApplication() registerForRemoteNotifications]` call) should only be made from the main thread.

This does not prompt the user on iOS after the first time the user responds to the dialog, so the user experience is not hurt by running this code over and over.