### PR TITLE
Add note to exact property that a minimum API version is required…

### DIFF
--- a/docs/notifications/reference/Schedule.md
+++ b/docs/notifications/reference/Schedule.md
@@ -7,7 +7,7 @@ Object giving information about the schedule to use for a notification.
 ### exact
 [method]exact returns nullable boolean;[/method]
 
-> Android only
+> Android only (Note: The minimum Android API version must be at least `19` to enable **exact** delivery times. You may set your minimum API level in: `android/build.gradle` > `buildscript.ext.minSdkVersion`)
 
 If the fireDate should be respected exactly, i.e. for reminders, or if it can deviate slightly to save battery.
 


### PR DESCRIPTION
… to enabled this flag.

After enabling **exact** for scheduled notifications, I found that Android was inconsistently delivering scheduled notifications outside the defined time. After some digging, I came across where the **exact** flag was handled in the Firebase module `notifications` and realized I needed to update my `minSdkVersion` (Android API Level) to enable this in all builds.

https://github.com/invertase/react-native-firebase/blob/v5.5.5/android/src/main/java/io/invertase/firebase/notifications/RNFirebaseNotificationManager.java#L650

I'm proposing a change to the documentation to help clarify the behavior around this flag and how it is enabled.

Please advise on whether or not this is the minimum version to enable this flag.

Thank you for the great work on this project, its an enormous help to the community :)