### PR TITLE
docs(analytics): max char length for event param name & value

### DIFF
--- a/docs/analytics/reference/analytics.md
+++ b/docs/analytics/reference/analytics.md
@@ -12,7 +12,7 @@ The following methods are accessed via the Analytics instance `firebase.analytic
 [method]logEvent(event, params) returns void;[/method]
 
 Log a custom event with optional params.
-Note: up to 100 characters is the maximum character length supported for event parameters.
+Note: up to 40 characters is the maximum character length supported for event parameter names, and up to 100 characters is the maximum character length supported for event parameter values.
 
 | Parameter |         |
 | --------- | ------- |

--- a/docs/analytics/reference/analytics.md
+++ b/docs/analytics/reference/analytics.md
@@ -12,7 +12,10 @@ The following methods are accessed via the Analytics instance `firebase.analytic
 [method]logEvent(event, params) returns void;[/method]
 
 Log a custom event with optional params.
+
 Note: up to 40 characters is the maximum character length supported for event parameter names, and up to 100 characters is the maximum character length supported for event parameter values.
+
+See [Collection and configuration limits](https://support.google.com/firebase/answer/9237506?hl=en) in Firebase Help for additional information.
 
 | Parameter |         |
 | --------- | ------- |


### PR DESCRIPTION
This PR clarifies the difference between the maximum character lengths supported for event parameter names and event parameter values.

Source: https://support.google.com/firebase/answer/9237506?hl=en