### PR TITLE
[Docs] update ios pod versions

### DIFF
--- a/docs/_config.yaml
+++ b/docs/_config.yaml
@@ -28,17 +28,17 @@ ios:
   fabric:
     tools: 1.10.2
   firebase:
-    ads: 6.3.0
-    auth: 6.3.0
-    config: 6.3.0
-    core: 6.3.0
-    crash: 6.3.0
+    ads: 6.13.0
+    auth: 6.13.0
+    config: 6.13.0
+    core: 6.13.0
+    crash: 6.13.0
     crashlytics: 3.13.2
-    database: 6.3.0
-    firestore: 6.3.0
-    functions: 6.3.0
-    invites: 6.3.0
-    links: 6.3.0
-    messaging: 6.3.0
-    perf: 6.3.0
-    storage: 6.3.0
+    database: 6.13.0
+    firestore: 6.13.0
+    functions: 6.13.0
+    invites: 6.13.0
+    links: 6.13.0
+    messaging: 6.13.0
+    perf: 6.13.0
+    storage: 6.13.0


### PR DESCRIPTION
I got really stuck trying to use version 5.6.0 on iOS because of the old version in the docs. This fixes that. 
Should close [#2998](https://github.com/invertase/react-native-firebase/issues/2998) in the main repo.