### PR TITLE
Add note that getInitialNotification only works release mode in iOS

### DIFF
--- a/docs/notifications/receiving-notifications.md
+++ b/docs/notifications/receiving-notifications.md
@@ -152,3 +152,5 @@ componentDidMount() {
       });
 }
 ```
+
+*Note: on iOS getInitialNotification appears to work in release mode only, per issue [#3095](https://github.com/invertase/react-native-firebase/issues/3095)*

--- a/docs/notifications/reference/Notifications.md
+++ b/docs/notifications/reference/Notifications.md
@@ -58,6 +58,9 @@ For notifications when the app is running, see [ref notifications#onNotification
 
 Returns the notification that caused the application to open if available, and the action that was invoked when it was clicked on.
 
+!> on iOS getInitialNotification appears to work in release mode only, per issue [#3095](https://github.com/invertase/react-native-firebase/issues/3095)*
+
+
 ### getScheduledNotifications
 [method]getScheduledNotifications() returns Promise containing Array of [ref notifications.Notification];[/method]
 


### PR DESCRIPTION

Issue 3095 (link below) appears to boil down to:

*Note: on iOS getInitialNotification appears to work in release mode only, per issue [#3095](https://github.com/invertase/react-native-firebase/issues/3095)*

Detective work by @7patricia confirm by @mstankov